### PR TITLE
add ability to register and call colon functions

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,8 +2,8 @@ all: kilo
 
 CFLAGS=-Wextra -pedantic -std=c11
 
-OBJS=kilo.o function.o process_keypress.o init.o syntax_highlighter.o
-INCLUDE=function.h kilo.h process_keypress.h init.h syntax_highlighter.h
+OBJS=kilo.o function.o process_keypress.o init.o syntax_highlighter.o colon.o
+INCLUDE=function.h kilo.h process_keypress.h init.h syntax_highlighter.h colon.h
 
 kilo: $(OBJS)
 	$(CC) -o kilo $(OBJS)

--- a/src/colon.c
+++ b/src/colon.c
@@ -1,0 +1,19 @@
+#include "colon.h"
+#include <stdio.h>
+
+void printHello() {
+  printf("Hello\n");
+}
+
+void (*lookupColonFunction(char *name))() {
+  return &printHello; // TODO implement key value store get
+}
+
+void handleColonFunction(char *name) {
+  void (*func)() = lookupColonFunction(name);
+  func();
+}
+
+void registerColonFunction(char *name, void (*func)()) {
+  // TODO implement key value store set
+}

--- a/src/colon.h
+++ b/src/colon.h
@@ -1,0 +1,7 @@
+#ifdef KILO_COLON_H
+#define KILO_COLON_H
+
+int handleColonFunction(char *name);
+void registerColonFunction(char *name, void (*func));
+
+#endif


### PR DESCRIPTION
Is this a fine API for the moment @epilk?

In your config you would call `registerColonFunction("fmt", &clangFormat)` and then type `:fmt`.
