### PR TITLE
add autocomplete to colon functions

### DIFF
--- a/src/colon.c
+++ b/src/colon.c
@@ -5,6 +5,45 @@
 
 static struct trie colonFunctions;
 
+char *lookupPartialColonFunction(char *partialName) {
+  struct trie *t = triePartialLookup(&colonFunctions, partialName);
+  if (t == NULL) {
+    return NULL;
+  }
+
+  int i, found;
+
+  int bufsz = 8;
+  int len = 0;
+  char *buf = malloc(bufsz);
+
+  for (;;) {
+    if (t->value != NULL) {
+      goto done;
+    }
+    found = -1;
+    for (i = 0; i < CHAR_MAX; i++) {
+      if (t->next[i] != NULL) {
+        if (found != -1) {
+          // There are multiple possible branches in the trie so return the
+          // current location.
+          goto done;
+        }
+        found = i;
+      }
+    }
+    t = t->next[found];
+    if (len + 1 >= bufsz) { // leave room for a null byte
+      buf = realloc(buf, bufsz *= 2);
+    }
+    buf[len++] = found;
+  }
+
+done:
+  buf[len] = '\0';
+  return buf;
+}
+
 void (*lookupColonFunction(char *name))() {
   return (void (*)())trieLookup(&colonFunctions, name);
 }

--- a/src/colon.h
+++ b/src/colon.h
@@ -3,5 +3,6 @@
 
 int handleColonFunction(char *name);
 void registerColonFunction(char *name, void (*func)());
+char *lookupPartialColonFunction(char *partialName);
 
 #endif

--- a/src/trie.c
+++ b/src/trie.c
@@ -28,13 +28,17 @@ void trieAddKeyValue(struct trie *t, char *key, void *value) {
   }
 }
 
-void *trieLookup(struct trie *t, char *key) {
+struct trie *triePartialLookup(struct trie *t, char *key) {
   struct trie *next;
   if (*key == '\0') {
-    return t->value;
+    return t;
   } else if ((next = t->next[(int)*key])) {
-    return trieLookup(next, key+1);
+    return triePartialLookup(next, key+1);
   } else {
     return NULL;
   }
+}
+
+void *trieLookup(struct trie *t, char *key) {
+  return triePartialLookup(t, key)->value;
 }

--- a/src/trie.h
+++ b/src/trie.h
@@ -12,5 +12,6 @@ struct trie {
 struct trie *newTrie();
 void trieAddKeyValue(struct trie *t, char *key, void *value);
 void *trieLookup(struct trie *t, char *key);
+struct trie *triePartialLookup(struct trie *t, char *key);
 
 #endif


### PR DESCRIPTION
This adds autocomplete to `:` functions. Hit TAB while in `:` and autocomplete will be triggered.

- If the cursor is in the middle of the buffer, it is automatically moved to the end.
- I've tested this out with some longer strings and it works well
- I also added an fflush call to the debugger
