### PR TITLE
add colon history with up and down arrow

### DIFF
--- a/src/colon.c
+++ b/src/colon.c
@@ -3,6 +3,9 @@
 #include "trie.h"
 #include <stddef.h>
 #include <stdio.h>
+#include <string.h>
+
+static char* history[HISTORY_SIZE];
 
 static struct trie colonFunctions;
 
@@ -49,7 +52,32 @@ void *lookupColonFunction(char *name) {
   return trieLookup(&colonFunctions, name);
 }
 
+void addToHistory(char *str) {
+  int len = strlen(str);
+  char *added = malloc(len + 1);
+  strcpy(added, str);
+
+  free(history[HISTORY_SIZE-1]);
+
+  // Shift all the entries up one.
+  int i;
+  for (i = HISTORY_SIZE-2; i >= 0; i--) {
+    history[i+1] = history[i];
+  }
+  history[0] = added;
+}
+
 int handleColonFunction(char *name, char *arg) {
+  // A sketchy hack that relies on name and arg being right beside eachother in
+  // memory.
+  if (arg != NULL) {
+    name[strlen(name)] = ' ';
+    addToHistory(name);
+    name[strlen(name)] = '\0';
+  } else {
+    addToHistory(name);
+  }
+
   void *func = lookupColonFunction(name);
   logmsg("retreiving: %s: %p\n", name, func);
   if (((ptrdiff_t)func) & 0x1) {
@@ -62,6 +90,13 @@ int handleColonFunction(char *name, char *arg) {
   } else {
     return 1;
   }
+}
+
+char *getHistoryAt(int i) {
+  if (i < 0 || i >= HISTORY_SIZE) {
+    return NULL;
+  }
+  return history[i];
 }
 
 void registerColonFunction(char *name, colonFunction *func) {

--- a/src/colon.h
+++ b/src/colon.h
@@ -1,6 +1,8 @@
 #ifndef KILO_COLON_H
 #define KILO_COLON_H
 
+#define HISTORY_SIZE 5
+
 typedef void colonFunction();
 typedef _Bool unaryColonFunction(char *);
 
@@ -8,5 +10,6 @@ int handleColonFunction(char *name, char *arg);
 void registerColonFunction(char *name, colonFunction *func);
 void registerColonFunctionWithArg(char *name, unaryColonFunction *func);
 char *lookupPartialColonFunction(char *partialName);
+char *getHistoryAt(int i);
 
 #endif


### PR DESCRIPTION
This adds history to `:` functions. Right now we don't have enough functions to make history valuable but some day someone will thank me.

Also... we segmentation faults when we try to find a `:` function that does not exist. eg `:foobarlol`. This bug is not added by this PR. Though it was probably my fault. :3 I'll fix it...